### PR TITLE
Changing title to Reset Password

### DIFF
--- a/learn/templates/registration/login.html
+++ b/learn/templates/registration/login.html
@@ -1,7 +1,4 @@
 {% extends 'base.html' %}
-{% block title %}
-	Login-Easy Learning 
-{% endblock %}
 {% block content %}
 	<div class="container">
 		<div class="well well-lg col-lg-offset-4 col-lg-4 col-md-offset-3 col-md-6 col-sm-offset-2 col-sm-8">

--- a/learn/templates/registration/login.html
+++ b/learn/templates/registration/login.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block title %}
+	Login-Easy Learning 
+{% endblock %}
 {% block content %}
 	<div class="container">
 		<div class="well well-lg col-lg-offset-4 col-lg-4 col-md-offset-3 col-md-6 col-sm-offset-2 col-sm-8">

--- a/learn/templates/registration/password_change_done.html
+++ b/learn/templates/registration/password_change_done.html
@@ -1,4 +1,7 @@
 {% extends 'learn/myaccount.html' %}
+{% block title %}
+	Reset Password 
+{% endblock %}
 {% load i18n %}
 {% block myaccount_content %}
 	<h2>Password Changed</h2>

--- a/learn/templates/registration/password_change_form.html
+++ b/learn/templates/registration/password_change_form.html
@@ -1,4 +1,7 @@
 {% extends 'learn/myaccount.html' %}
+{% block title %}
+	Reset Password 
+{% endblock %}
 {% load i18n %}
 {% block myaccount_content %}
 <form method="post">

--- a/learn/templates/registration/password_reset_complete.html
+++ b/learn/templates/registration/password_reset_complete.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
-
+{% block title %}
+  Reset Password 
+{% endblock %}
 {% block content %}
   <p>
     Your password has been set. You may go ahead and <a href="{% url 'login' %}">sign in</a> now.

--- a/learn/templates/registration/password_reset_confirm.html
+++ b/learn/templates/registration/password_reset_confirm.html
@@ -1,5 +1,9 @@
 {% extends 'base.html' %}
 
+{% block title %}
+	Reset Password 
+{% endblock %}
+
 {% block content %}
   {% if validlink %}
     <h3>Change password</h3>

--- a/learn/templates/registration/password_reset_done.html
+++ b/learn/templates/registration/password_reset_done.html
@@ -1,5 +1,9 @@
 {% extends 'base.html' %}
 
+{% block title %}
+	Reset Password 
+{% endblock %}
+
 {% block content %}
 	<div class="container">
 		<p>

--- a/learn/templates/registration/password_reset_email.html
+++ b/learn/templates/registration/password_reset_email.html
@@ -1,4 +1,7 @@
 {% load i18n %}{% autoescape off %}
+{% block title %}
+	Reset Password 
+{% endblock %}
 {% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new password:" %}

--- a/learn/templates/registration/password_reset_form.html
+++ b/learn/templates/registration/password_reset_form.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block title %}
+	Reset Password 
+{% endblock %}
 {% block content %}
 	<div class="container">
 		<div class="well well-lg col-lg-offset-4 col-lg-4 col-md-offset-3 col-md-6 col-sm-offset-2 col-sm-8">


### PR DESCRIPTION
All pages corresponding to change of password will now have title 'Reset Password' instead of 'Start Learning'...