### PR TITLE
added title tag to Reset Password

### DIFF
--- a/learn/templates/registration/password_change_done.html
+++ b/learn/templates/registration/password_change_done.html
@@ -1,6 +1,6 @@
 {% extends 'learn/myaccount.html' %}
 {% block title %}
-	Reset Password
+	<title>Reset Password</title>
 {% endblock %}
 {% load i18n %}
 {% block myaccount_content %}

--- a/learn/templates/registration/password_change_form.html
+++ b/learn/templates/registration/password_change_form.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load widget_tweaks %}
 {% block title %}
-	Reset Password
+	<title>Reset Password</title>
 {% endblock %}
 {% block myaccount_content %}
 <form method="post">

--- a/learn/templates/registration/password_reset_complete.html
+++ b/learn/templates/registration/password_reset_complete.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}
-	Reset Password
+	<title>Reset Password</title>
 {% endblock %}
 {% block content %}
   <p>

--- a/learn/templates/registration/password_reset_confirm.html
+++ b/learn/templates/registration/password_reset_confirm.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}
-	Reset Password
+	<title>Reset Password</title>
 {% endblock %}
 {% block content %}
   {% if validlink %}

--- a/learn/templates/registration/password_reset_done.html
+++ b/learn/templates/registration/password_reset_done.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}
-	Reset Password
+	<title>Reset Password</title>
 {% endblock %}
 {% block content %}
 	<div class="container">

--- a/learn/templates/registration/password_reset_email.html
+++ b/learn/templates/registration/password_reset_email.html
@@ -1,6 +1,6 @@
 {% load i18n %}{% autoescape off %}
 {% block title %}
-	Reset Password
+	<title>Reset Password</title>
 {% endblock %}
 {% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
 

--- a/learn/templates/registration/password_reset_form.html
+++ b/learn/templates/registration/password_reset_form.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}
-	Reset Password
+	<title>Reset Password</title>
 {% endblock %}
 {% block content %}
 	<div class="container">


### PR DESCRIPTION
In all the HTML template files inside learn/templates/registration related to forgot password, 'Reset Password' text is now enclosed within <title> tag.